### PR TITLE
bugfix: each map, list or object should be stored into an array as it…

### DIFF
--- a/hessian2.py
+++ b/hessian2.py
@@ -728,16 +728,21 @@ class Hessian2Deserializer:
 
     def _read_fixed_length_list(self, length: int, cls_name: str = None) -> Union[list, UserList]:
         l = [None] * length
+        ref_idx = len(self._refs)
+        self._refs.append(l)  # per hessian2 spec, list should be added to refs when parsing
         for i in range(length):
             l[i] = self.read()
         if cls_name:
             typed_list = UserList(l)
             typed_list.__dict__['#class'] = cls_name
+            self._refs[ref_idx] = typed_list  # update ref to the actual returned object
             return typed_list
         return l
 
     def _read_variable_length_list(self, cls_name: str = None) -> Union[list, UserList]:
         l = []
+        ref_idx = len(self._refs)
+        self._refs.append(l)  # per hessian2 spec, list should be added to refs when parsing
         while True:
             b = self._reader.look_byte()
             if b == 0x5a:
@@ -747,6 +752,7 @@ class Hessian2Deserializer:
         if cls_name:
             typed_list = UserList(l)
             typed_list.__dict__['#class'] = cls_name
+            self._refs[ref_idx] = typed_list  # update ref to the actual returned object
             return typed_list
         return l
 
@@ -781,6 +787,7 @@ class Hessian2Deserializer:
         else:
             raise ValueError(f'token error {b} at {self._reader.pos()}')
         v = {'#class': cls_definition.cls_name}
+        self._refs.append(v)  # per hessian2 spec, object should be added to refs when parsing
         for field_name in cls_definition.field_names:
             v[field_name] = self.read()
         return v


### PR DESCRIPTION
as [http://hessian.caucho.com/doc/hessian-serialization.html](http://hessian.caucho.com/doc/hessian-serialization.html) 4.11 says:
> An integer referring to a previous list, map, or object instance. As each list, map or object is read from the input stream, it is assigned the integer position in the stream, i.e. the first list or map is '0', the next is '1', etc. A later ref can then use the previous object. Writers MAY generate refs. Parsers MUST be able to recognize them.

> ref can refer to incompletely-read items. For example, a circular linked-list will refer to the first link before the entire list has been read.

> A possible implementation would add each map, list, and object to an array as it is read. The ref will return the corresponding value from the array. To support circular structures, the implementation would store the map, list or object immediately, before filling in the contents.

> Each map or list is stored into an array as it is parsed. ref selects one of the stored objects. The first object is numbered '0'.



But now only map will be put to the ref.
