### PR TITLE
bugfix: list should be added to the reference list when encoding & add tests

### DIFF
--- a/hessian2.py
+++ b/hessian2.py
@@ -335,6 +335,12 @@ class Hessian2Serializer:
         #      ::= x58 int value*        # fixed-length untyped list
         #      ::= [x70-77] type value*  # fixed-length typed list
         #      ::= [x78-7f] value*       # fixed-length untyped list
+        if v is None:
+            self.write_null()
+            return
+        if self._try_write_ref(v):
+            return
+
         l = len(v)
         cls_name = str(v.__dict__['#class']) if hasattr(v, '__dict__') and '#class' in v.__dict__ else None
 

--- a/pytest/test_main.py
+++ b/pytest/test_main.py
@@ -3,7 +3,7 @@ import os
 import unittest
 from collections import UserList
 
-from hessian2 import dumps, loads
+from hessian2 import dumps, loads, TypeConstants
 
 
 class Test(unittest.TestCase):
@@ -287,6 +287,99 @@ class Test(unittest.TestCase):
 
     def test_decode_object(self):
         self.assertEqual(loads(b'\x43\x19\x6f\x72\x67\x2e\x65\x78\x61\x6d\x70\x6c\x65\x2e\x4d\x61\x69\x6e\x24\x54\x65\x73\x74\x42\x65\x61\x6e\x92\x01\x61\x01\x62\x60\x91\x01\x62'), {'#class': 'org.example.Main$TestBean', 'a': 1, 'b': 'b'})
+
+    def test_decode_list_with_ref(self):
+        """Test list containing reference to itself or other lists"""
+        # Case 1: A list that contains a reference to itself: [1, ref(0)]
+        # 0x7a = fixed untyped list length 2
+        # 0x91 = int 1
+        # 0x51 0x90 = ref(0) - reference to the list itself
+        data = b'\x7a\x91\x51\x90'
+        result = loads(data)
+        self.assertEqual(result[0], 1)
+        self.assertIs(result[1], result)  # The second element should be the list itself
+
+        # Case 2: Map containing two keys referencing the same list
+        # { 'a': [1, 2], 'b': ref(1) }
+        # H = 0x48, 'a' = 0x01 0x61, [1,2] = 0x7a 0x91 0x92 (refs[1])
+        # 'b' = 0x01 0x62, ref(1) = 0x51 0x91, Z = 0x5a
+        data = b'\x48\x01\x61\x7a\x91\x92\x01\x62\x51\x91\x5a'
+        result = loads(data)
+        self.assertEqual(result['a'], [1, 2])
+        self.assertIs(result['a'], result['b'])
+
+        # Case 3: Variable length list with self-reference
+        # W value ref(0) Z - variable length untyped list
+        # 0x57 = variable length untyped list
+        # 0x91 = int 1
+        # 0x51 0x90 = ref(0)
+        # 0x5a = Z (end of list)
+        data = b'\x57\x91\x51\x90\x5a'
+        result = loads(data)
+        self.assertEqual(result[0], 1)
+        self.assertIs(result[1], result)
+
+    def test_decode_object_with_ref(self):
+        """Test object containing reference to itself"""
+        # Define class 'T' with fields 'a' and 'b', where b references the object itself
+        # C 'T' 2 'a' 'b' O(0) 1 ref(0)
+        # C = 0x43
+        # 'T' = 0x01 0x54
+        # 2 = 0x92
+        # 'a' = 0x01 0x61
+        # 'b' = 0x01 0x62
+        # 0x60 = object with direct type 0
+        # 0x91 = int 1
+        # 0x51 0x90 = ref(0) - reference to the object itself
+        data = b'\x43\x01\x54\x92\x01\x61\x01\x62\x60\x91\x51\x90'
+        result = loads(data)
+        self.assertEqual(result['#class'], 'T')
+        self.assertEqual(result['a'], 1)
+        self.assertIs(result['b'], result)  # 'b' should reference the object itself
+
+    def test_decode_object_referenced_by_other(self):
+        """Test multiple references to the same object"""
+        # { 'obj1': Object{a:1}, 'obj2': ref(1) }
+        # H = 0x48
+        # 'obj1' = 0x04 obj1
+        # C 'X' 1 'a' O(0) 1  -> defines and creates object
+        # 'obj2' = 0x04 obj2
+        # ref(1) = 0x51 0x91
+        # Z = 0x5a
+        data = b'\x48\x04obj1\x43\x01\x58\x91\x01\x61\x60\x91\x04obj2\x51\x91\x5a'
+        result = loads(data)
+        self.assertEqual(result['obj1']['#class'], 'X')
+        self.assertEqual(result['obj1']['a'], 1)
+        self.assertIs(result['obj1'], result['obj2'])
+
+    def test_decode_typed_list_with_ref(self):
+        """Test typed list with reference"""
+        # Typed list [int: 1, 2] and then reference to it
+        # { 'arr': [int:1,2], 'arr2': ref(1) }
+        # H = 0x48
+        # 'arr' = 0x03 arr
+        # 0x72 = fixed typed list length 2
+        # '[int' = 0x04 [int
+        # 0x91 0x92 = int 1, 2
+        # 'arr2' = 0x04 arr2
+        # ref(1) = 0x51 0x91
+        # Z = 0x5a
+        data = b'\x48\x03arr\x72\x04[int\x91\x92\x04arr2\x51\x91\x5a'
+        result = loads(data)
+        self.assertEqual(list(result['arr']), [1, 2])
+        self.assertEqual(result['arr'].__dict__['#class'], '[int')
+        self.assertIs(result['arr'], result['arr2'])
+
+    def test_decode_nested_ref(self):
+        """Test nested structures with references"""
+        # [map, ref(0)] - list containing a map and ref to itself
+        # 0x7a = fixed untyped list length 2
+        # H 'k' 'v' Z = simple map
+        # 0x51 0x90 = ref(0) to the list
+        data = b'\x7a\x48\x01k\x01v\x5a\x51\x90'
+        result = loads(data)
+        self.assertEqual(result[0], {'k': 'v'})
+        self.assertIs(result[1], result)
 
     @staticmethod
     def _read_file(filename: str) -> bytes:

--- a/pytest/test_main.py
+++ b/pytest/test_main.py
@@ -288,8 +288,27 @@ class Test(unittest.TestCase):
     def test_decode_object(self):
         self.assertEqual(loads(b'\x43\x19\x6f\x72\x67\x2e\x65\x78\x61\x6d\x70\x6c\x65\x2e\x4d\x61\x69\x6e\x24\x54\x65\x73\x74\x42\x65\x61\x6e\x92\x01\x61\x01\x62\x60\x91\x01\x62'), {'#class': 'org.example.Main$TestBean', 'a': 1, 'b': 'b'})
 
+    def test_encode_list_with_ref(self):
+        """Test encoding list with references"""
+        # Same list referenced twice in a map should use ref
+        l = [1, 2]
+        data = {'a': l, 'b': l}
+        encoded = dumps(data)
+        decoded = loads(encoded)
+        self.assertEqual(decoded['a'], [1, 2])
+        self.assertIs(decoded['a'], decoded['b'])  # Should be the same object
+
+        # Nested lists with same reference
+        inner = [3, 4]
+        outer = [inner, inner, 5]
+        encoded = dumps(outer)
+        decoded = loads(encoded)
+        self.assertEqual(decoded[0], [3, 4])
+        self.assertIs(decoded[0], decoded[1])
+        self.assertEqual(decoded[2], 5)
+
     def test_decode_list_with_ref(self):
-        """Test list containing reference to itself or other lists"""
+        """Test decoding list containing reference to itself or other lists"""
         # Case 1: A list that contains a reference to itself: [1, ref(0)]
         # 0x7a = fixed untyped list length 2
         # 0x91 = int 1
@@ -319,8 +338,19 @@ class Test(unittest.TestCase):
         self.assertEqual(result[0], 1)
         self.assertIs(result[1], result)
 
+    def test_encode_object_with_ref(self):
+        """Test encoding object with self-reference"""
+        # Create a self-referencing object (map with #class)
+        obj = {'#class': 'SelfRef', 'value': 1}
+        obj['self'] = obj  # Self reference
+        encoded = dumps(obj)
+        decoded = loads(encoded)
+        self.assertEqual(decoded['#class'], 'SelfRef')
+        self.assertEqual(decoded['value'], 1)
+        self.assertIs(decoded['self'], decoded)
+
     def test_decode_object_with_ref(self):
-        """Test object containing reference to itself"""
+        """Test decoding object containing reference to itself"""
         # Define class 'T' with fields 'a' and 'b', where b references the object itself
         # C 'T' 2 'a' 'b' O(0) 1 ref(0)
         # C = 0x43
@@ -337,8 +367,19 @@ class Test(unittest.TestCase):
         self.assertEqual(result['a'], 1)
         self.assertIs(result['b'], result)  # 'b' should reference the object itself
 
+    def test_encode_object_referenced_by_other(self):
+        """Test encoding multiple references to the same object"""
+        # Same object (map with #class) referenced twice
+        obj = {'#class': 'SharedObj', 'a': 1}
+        data = {'obj1': obj, 'obj2': obj}
+        encoded = dumps(data)
+        decoded = loads(encoded)
+        self.assertEqual(decoded['obj1']['#class'], 'SharedObj')
+        self.assertEqual(decoded['obj1']['a'], 1)
+        self.assertIs(decoded['obj1'], decoded['obj2'])
+
     def test_decode_object_referenced_by_other(self):
-        """Test multiple references to the same object"""
+        """Test decoding multiple references to the same object"""
         # { 'obj1': Object{a:1}, 'obj2': ref(1) }
         # H = 0x48
         # 'obj1' = 0x04 obj1
@@ -352,8 +393,20 @@ class Test(unittest.TestCase):
         self.assertEqual(result['obj1']['a'], 1)
         self.assertIs(result['obj1'], result['obj2'])
 
+    def test_encode_typed_list_with_ref(self):
+        """Test encoding typed list with reference"""
+        # Same typed list referenced twice
+        typed_list = UserList([1, 2])
+        typed_list.__dict__['#class'] = '[int'
+        data = {'arr': typed_list, 'arr2': typed_list}
+        encoded = dumps(data)
+        decoded = loads(encoded)
+        self.assertEqual(list(decoded['arr']), [1, 2])
+        self.assertEqual(decoded['arr'].__dict__['#class'], '[int')
+        self.assertIs(decoded['arr'], decoded['arr2'])
+
     def test_decode_typed_list_with_ref(self):
-        """Test typed list with reference"""
+        """Test decoding typed list with reference"""
         # Typed list [int: 1, 2] and then reference to it
         # { 'arr': [int:1,2], 'arr2': ref(1) }
         # H = 0x48
@@ -370,8 +423,19 @@ class Test(unittest.TestCase):
         self.assertEqual(result['arr'].__dict__['#class'], '[int')
         self.assertIs(result['arr'], result['arr2'])
 
+    def test_encode_nested_ref(self):
+        """Test encoding nested structures with references"""
+        # Nested map containing same inner map multiple times
+        inner = {'k': 'v'}
+        outer = {'a': inner, 'b': [inner, inner]}
+        encoded = dumps(outer)
+        decoded = loads(encoded)
+        self.assertEqual(decoded['a'], {'k': 'v'})
+        self.assertIs(decoded['a'], decoded['b'][0])
+        self.assertIs(decoded['b'][0], decoded['b'][1])
+
     def test_decode_nested_ref(self):
-        """Test nested structures with references"""
+        """Test decoding nested structures with references"""
         # [map, ref(0)] - list containing a map and ref to itself
         # 0x7a = fixed untyped list length 2
         # H 'k' 'v' Z = simple map
@@ -381,18 +445,8 @@ class Test(unittest.TestCase):
         self.assertEqual(result[0], {'k': 'v'})
         self.assertIs(result[1], result)
 
-    def test_encode_list_with_ref(self):
-        """Test serializer correctly uses ref for duplicate lists"""
-        # Same list referenced twice in a map should use ref
-        l = [1, 2]
-        data = {'a': l, 'b': l}
-        encoded = dumps(data)
-        decoded = loads(encoded)
-        self.assertEqual(decoded['a'], [1, 2])
-        self.assertIs(decoded['a'], decoded['b'])  # Should be the same object
-
     def test_encode_map_with_ref(self):
-        """Test serializer correctly uses ref for duplicate maps"""
+        """Test encoding map with references"""
         # Same map referenced twice should use ref
         m = {'x': 1}
         data = {'a': m, 'b': m}
@@ -400,6 +454,20 @@ class Test(unittest.TestCase):
         decoded = loads(encoded)
         self.assertEqual(decoded['a'], {'x': 1})
         self.assertIs(decoded['a'], decoded['b'])  # Should be the same object
+
+    def test_decode_map_with_ref(self):
+        """Test decoding map with references"""
+        # { 'a': {x:1}, 'b': ref(1) }
+        # H = 0x48
+        # 'a' = 0x01 0x61
+        # H 'x' 1 Z = 0x48 0x01 0x78 0x91 0x5a (refs[1])
+        # 'b' = 0x01 0x62
+        # ref(1) = 0x51 0x91
+        # Z = 0x5a
+        data = b'\x48\x01\x61\x48\x01\x78\x91\x5a\x01\x62\x51\x91\x5a'
+        result = loads(data)
+        self.assertEqual(result['a'], {'x': 1})
+        self.assertIs(result['a'], result['b'])
 
     @staticmethod
     def _read_file(filename: str) -> bytes:

--- a/pytest/test_main.py
+++ b/pytest/test_main.py
@@ -381,6 +381,26 @@ class Test(unittest.TestCase):
         self.assertEqual(result[0], {'k': 'v'})
         self.assertIs(result[1], result)
 
+    def test_encode_list_with_ref(self):
+        """Test serializer correctly uses ref for duplicate lists"""
+        # Same list referenced twice in a map should use ref
+        l = [1, 2]
+        data = {'a': l, 'b': l}
+        encoded = dumps(data)
+        decoded = loads(encoded)
+        self.assertEqual(decoded['a'], [1, 2])
+        self.assertIs(decoded['a'], decoded['b'])  # Should be the same object
+
+    def test_encode_map_with_ref(self):
+        """Test serializer correctly uses ref for duplicate maps"""
+        # Same map referenced twice should use ref
+        m = {'x': 1}
+        data = {'a': m, 'b': m}
+        encoded = dumps(data)
+        decoded = loads(encoded)
+        self.assertEqual(decoded['a'], {'x': 1})
+        self.assertIs(decoded['a'], decoded['b'])  # Should be the same object
+
     @staticmethod
     def _read_file(filename: str) -> bytes:
         with open(os.getcwd() + '/pytest/' + filename, 'r') as f:


### PR DESCRIPTION
as [http://hessian.caucho.com/doc/hessian-serialization.html](http://hessian.caucho.com/doc/hessian-serialization.html) 4.6 says:

>  Each list item is added to the reference list to handle shared and circular elements. See the ref element.

But now only map will be added to the reference list while list will not.