### PR TITLE
fix: short Hessian2 strings must use length 0–31 for 0x00–0x1f opcode

### DIFF
--- a/hessian2.py
+++ b/hessian2.py
@@ -15,7 +15,7 @@ Hessian 2.0 Protocol
 see http://hessian.caucho.com/doc/hessian-serialization.html
 
 Hessian Bytecode map:
-    x00 - x1f    # utf-8 string length 0-32
+    x00 - x1f    # utf-8 string length 0-31
     x20 - x2f    # binary data length 0-16
     x30 - x33    # utf-8 string length 0-1023
     x34 - x37    # binary data length 0-1023
@@ -237,8 +237,8 @@ class Hessian2Serializer:
 
         l = self._calc_string_length(v)  # 按字符计算，而不是按字节
 
-        if l <= 32:
-            # utf-8 string length 0-32
+        if l <= 31:
+            # utf-8 string length 0-31（0x20 起为 binary 短格式，不可用于字符串）
             self._bytes.append(0x00 + l)
             self._write_utf8_bytes(v)
         elif l <= 1023:

--- a/pytest/test_main.py
+++ b/pytest/test_main.py
@@ -155,6 +155,16 @@ class Test(unittest.TestCase):
         self.assertEqual(loads(b'\x03\xf0\x9f\x9a\x80\xf0\x9f\x8c\x9f\xf0\x9f\x98\x8a'), '🚀🌟😊')
         self.assertEqual(loads(b'\x06\xed\xa0\xbd\xed\xba\x80\xed\xa0\xbc\xed\xbc\x9f\xed\xa0\xbd\xed\xb8\x8a'), '🚀🌟😊')
 
+    def test_string_compact_length_31_32_boundary(self):
+        # Single-byte string tags are 0x00-0x1f (length 0-31). 0x20 is compact binary, not UTF-8 string.
+        s31 = 'a' * 31
+        s32 = 'a' * 32
+        self.assertEqual(dumps(s31), b'\x1f' + b'a' * 31)
+        self.assertEqual(dumps(s32), b'\x30\x20' + b'a' * 32)
+        self.assertEqual(loads(dumps(s31)), s31)
+        self.assertEqual(loads(dumps(s32)), s32)
+        self.assertEqual(loads(b'\x30\x20' + b'a' * 32), s32)
+
     def test_encode_date(self):
         self.assertEqual(dumps(datetime.datetime(2021, 2, 3, 11, 22, 33)), b'\x4a\x00\x00\x01\x77\x65\xe9\xbc\xa8')
 


### PR DESCRIPTION
## Summary
- Short UTF-8 string encoding used l <= 32, so a 32-character string was written with tag 0x20. In Hessian 2.0, 0x20–0x2f is compact binary, not string; the dispatcher in this codebase routes 0x00–0x1f to read_string() and 0x20–0x2f to read_bytes(). That made 32-character strings serialize incorrectly and fail round-trip (or be mis-decoded as binary).

## Changes
- Use l <= 31 for the single-byte length prefix so the tag stays in 0x00–0x1f.
- Strings of length 32 use the existing 0x30 + length low byte path (e.g. 0x30 0x20 + UTF-8 payload).
- Align the bytecode map comment and inline note with the spec: 0x00–0x1f ⇒ length 0–31.

## Verification
- Round-trip dumps / loads for a 32-character ASCII string succeeds and uses the two-byte length header instead of 0x20.